### PR TITLE
Add suppport for Forgeo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ result
 
 # go
 cix
+
+# cix config
+config.json

--- a/Readme.md
+++ b/Readme.md
@@ -107,7 +107,7 @@ Depending on your needs the following might be useful
         - `user` (required) The Forgejo user name
         - `repository` (required) Repository name for that users account
         - `token` (optional) An Access Token with write permission for `repository`
-        - `ssh` (optional) Wether to use ssh or https to clone the repository
+        - `ssh` (optional) Whether to use ssh or https to clone the repository
     - `ssh` (optional)
         - `remote` (required) An ssh git url to pull commits from
 

--- a/Readme.md
+++ b/Readme.md
@@ -33,8 +33,8 @@ It is early days for Cix, but if you wish to try it, create a `config.json` simi
 }
 ```
 
-The `statuspat` is technically optional, but the commit tick in Github/Bitbucket is currently the only way to view results.
-See below for the Bitbucket equivalent, and details of what permissions to allow on the token.
+The `statuspat` is technically optional, but the commit tick in Github/Bitbucket/Forgejo is currently the only way to view results.
+See below for the Bitbucket/Forgejo equivalent, and details of what permissions to allow on the token.
 
 Cix will use git to pull the repositories over SSH, using whatever permissions are available in that context.
 Cix is designed so that it doesn't need to run continuously, if it is running your laptop when it goes to sleep, it will pull and run tests again on wake.
@@ -45,7 +45,7 @@ Cix was inspired by [nix-simple-ci](https://github.com/ElvishJerricco/nix-simple
 
 - **Watches repositories**
 - **Runs tests** with `nix flake check`
-- **Pushes a commit status to Github//Bitbucket** so you can see if the tests are running, passed or failed
+- **Pushes a commit status to Github//Bitbucket/Forgejo** so you can see if the tests are running, passed or failed
 - **Catches up** Cix doesn't need to be online when the commit is made, so if you only have your machine on part the time, when it first checks it will enumerate and test all commits made since it was last on
 
 Cix will run tests for every commit, not just the latest commit pushed.
@@ -102,10 +102,16 @@ Depending on your needs the following might be useful
         - `workspace` (required) The Bitbucket workspace name
         - `repository` (required) The Bitbucket repository slug
         - `token` (optional) An Access Token with write permission for the repository
+    - `forgejo` (optional)
+        - `domain` (required) Domain of the Forgejo instance.
+        - `user` (required) The Forgejo user name
+        - `repository` (required) Repository name for that users account
+        - `token` (optional) An Access Token with write permission for `repository`
+        - `ssh` (optional) Wether to use ssh or https to clone the repository
     - `ssh` (optional)
         - `remote` (required) An ssh git url to pull commits from
 
-Although `github`, `bitbucket`, `ssh` fields are all optional, you must have at least one per repository specified.
+Although `github`, `bitbucket`, `forgejo`, `ssh` fields are all optional, you must have at least one per repository specified.
 If more than one is specified the outcome is undefined.
 
 ## Licence

--- a/config.go
+++ b/config.go
@@ -26,6 +26,9 @@ type RepositoryConfiguration struct {
 	// (optional) Ssh config block
 	Ssh *SshConfiguration
 
+	// (optional) Forgejo config block
+	Forgejo *ForgejoConfiguration
+
 	// The branch to check
 	Branch string
 }
@@ -41,6 +44,10 @@ func (rc RepositoryConfiguration) Source() RepoSource {
 
 	if rc.Ssh.Valid() {
 		return rc.Ssh
+	}
+
+	if rc.Forgejo.Valid() {
+		return rc.Forgejo
 	}
 
 	return nil

--- a/forgejo.go
+++ b/forgejo.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"bytes"
+	"io"
+)
+
+type ForgejoConfiguration struct {
+	Domain string
+	User string
+	Repository string
+	Token string
+	Ssh bool
+}
+
+func (fc *ForgejoConfiguration) Valid() bool {
+	if fc == nil {
+		return false
+	}
+	return fc.Domain != "" && fc.User != "" && fc.Repository != ""
+}
+
+func (fc *ForgejoConfiguration)	SetStatus(status CiStatus, comment, description, hash string) error {
+	if fc.Token == "" {
+		return nil
+	}
+	url := fmt.Sprintf("https://%v/api/v1/repos/%v/%v/statuses/%v", fc.Domain, fc.User, fc.Repository, hash)
+
+	forgejoStatus := "error"
+	switch status {
+		case KInProgress:
+			forgejoStatus = "pending"
+		case KFailed:
+			forgejoStatus = "failure"
+		case KError:
+			forgejoStatus = "error"
+		case KSucceeded:
+			forgejoStatus = "success"
+	}
+
+	if len(description) > 255 {
+		description = description[:253] + "..."
+	}
+
+	body := []byte(fmt.Sprintf(`{"state":"%s","context": "%s","description":"%s"}`, forgejoStatus, comment, description))
+
+	r, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+	if err != nil {
+		return fmt.Errorf("Failed to start post: %v", err)
+	}
+	r.Header.Add("Content-Type", "application/json")
+	r.Header.Add("Authorization", fmt.Sprintf("token %s", fc.Token))
+
+	client := &http.Client{}
+	res, err := client.Do(r)
+	if err != nil {
+		return fmt.Errorf("Error posting forgejo status: %v", err)
+	}
+
+	body, _ = io.ReadAll(res.Body)
+
+	res.Body.Close()
+
+	if res.StatusCode != 200 && res.StatusCode != 201 {
+		fmt.Println(res.StatusCode)
+		fmt.Println(string(body))
+	}
+	return nil	
+}
+
+func (fc *ForgejoConfiguration)	NixUrl(revision string) string {
+	if !fc.Ssh {
+		return fmt.Sprintf("git+https://%s/%s/%s?rev=%s", fc.Domain, fc.User, fc.Repository, revision)
+	}
+	return fmt.Sprintf("git+ssh://git@%s/%s/%s?rev=%s", fc.Domain, fc.User, fc.Repository, revision)
+}
+
+func (fc *ForgejoConfiguration) GitUrl() string {
+	if !fc.Ssh {
+		return fmt.Sprintf("https://%s/%s/%s.git", fc.Domain, fc.User, fc.Repository)
+	}
+	return fmt.Sprintf("git@%s:%s/%s.git", fc.Domain, fc.User, fc.Repository)
+}


### PR DESCRIPTION
Implements support for [Forgejo](https://forgejo.org/), an open source and self-hostable code forge. (This will propably also work on Gitea as Forgejo forked from it)

The only problem I encountered is that the Forgejo frontend does not show long descriptions of commit statuses:
![image](https://github.com/user-attachments/assets/b6eb4109-e7f0-4654-962b-8c3b6cfa08b4)
